### PR TITLE
Allow multiple snap files

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -977,12 +977,15 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const loginData = core.getInput('store_login');
-            const snapFile = core.getInput('snap');
+            const snapFiles = core.getInput('snap').split(':');
             const release = core.getInput('release');
-            core.info(`Publishing snap "${snapFile}"...`);
-            const publisher = new publish_1.SnapcraftPublisher(loginData, snapFile, release);
-            yield publisher.validate();
-            yield publisher.publish();
+            for (let snap of snapFiles) {
+                snap = snap.trim();
+                core.info(`Publishing snap "${snap}"...`);
+                const publisher = new publish_1.SnapcraftPublisher(loginData, snap, release);
+                yield publisher.validate();
+                yield publisher.publish();
+            }
         }
         catch (error) {
             core.setFailed(error.message);

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,13 +6,16 @@ import {SnapcraftPublisher} from './publish'
 async function run(): Promise<void> {
   try {
     const loginData: string = core.getInput('store_login')
-    const snapFile: string = core.getInput('snap')
+    const snapFiles: string[] = core.getInput('snap').split(':')
     const release: string = core.getInput('release')
-    core.info(`Publishing snap "${snapFile}"...`)
 
-    const publisher = new SnapcraftPublisher(loginData, snapFile, release)
-    await publisher.validate()
-    await publisher.publish()
+    for (let snap of snapFiles) {
+      snap = snap.trim()
+      core.info(`Publishing snap "${snap}"...`)
+      const publisher = new SnapcraftPublisher(loginData, snap, release)
+      await publisher.validate()
+      await publisher.publish()
+    }
   } catch (error) {
     core.setFailed(error.message)
   }


### PR DESCRIPTION
This corresponds to jhenstridge/snapcraft-build-action#4. Multiple snap packages should be separated by colons: `:`

Signed-off-by: Daniel Llewellyn <daniel@bowlhat.net>